### PR TITLE
Store refreshed data when using _refresh suffix

### DIFF
--- a/redash_reql/query_runner.py
+++ b/redash_reql/query_runner.py
@@ -146,7 +146,9 @@ def create_tables_from_queries(user, conn, queries):
 
         results = json.loads(results)
 
-        create_table(conn, q.name, results)
+        # Do not generate an additional table to store data
+        # in case we obtained the latest data from the source
+        create_table(conn, re.sub('_refresh$', '', q.name), results)
         done.add(q.name)
 
 


### PR DESCRIPTION
I'm facing the following scenario:

```sql
SELECT *
FROM query_xx
```
Under normal circumstances I prefer using query_xx cached results,
as it reduces considerably the latency.

However, it may happen that you realise there was a bug in the data source
(usually that query_xx is not refreshing with the frequency it should 😊 ),
and therefore you want to invalidate the data and run the query again.
Upon fixing anything wrong in query_xx, if I execute:

```sql
SELECT *
FROM query_xx_refresh
```
the expected results are obtained.

However, it takes some time for this command to return the valid data:

```sql
SELECT *
FROM query_xx
```

If you agree this is unexpected behaviour, this change should solve the issue.

*NOTE*: I didn't manage to run locally unit tests :(

*NOTE 2*: as playcom-3 is a tag, I cannot reference it as the PR target